### PR TITLE
Update to 9.3.1 (9-2020-q2-update).

### DIFF
--- a/gcc-arm-embedded.nuspec
+++ b/gcc-arm-embedded.nuspec
@@ -4,7 +4,7 @@
   <metadata>
     <!-- == PACKAGE SPECIFIC SECTION == -->
     <id>gcc-arm-embedded</id>
-    <version>9.2.1</version>
+    <version>9.3.1</version>
     <packageSourceUrl>https://github.com/n3rd4i/gcc-arm-embedded</packageSourceUrl>
     <!-- owners is a poor name for maintainers of the package. It sticks around by this name for compatibility reasons. It basically means you. -->
     <owners>n3r4i</owners>

--- a/tools/chocolateyinstall.ps1
+++ b/tools/chocolateyinstall.ps1
@@ -1,12 +1,12 @@
 ﻿$ErrorActionPreference = 'Stop';
 $toolsDir   = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
-$url        = 'https://developer.arm.com/-/media/Files/downloads/gnu-rm/9-2019q4/gcc-arm-none-eabi-9-2019-q4-major-win32.zip'
+$url        = 'https://developer.arm.com/-/media/Files/downloads/gnu-rm/9-2020q2/gcc-arm-none-eabi-9-2020-q2-update-win32.zip'
 $packageArgs = @{
   packageName   = $env:ChocolateyPackageName
   unzipLocation = $toolsDir
   url           = $url
   softwareName  = 'gcc-arm-embedded*'
-  checksum      = 'E4C964ADD8D0FDCC6B14F323E277A0946456082A84A1CC560DA265B357762B62'
+  checksum      = '49d6029ecd176deaa437a15b3404f54792079a39f3b23cb46381b0e6fbbe9070'
   checksumType  = 'sha256'
 }
 Install-ChocolateyZipPackage @packageArgs


### PR DESCRIPTION
This is the most recent GNU Arm Embedded Toolchain version published, and includes several important fixes.